### PR TITLE
WIP allow error structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,26 +51,7 @@ If you only have a single error case you can also generate a struct:
 extern crate custom_error;
 use custom_error::custom_error;
 
-// Note the use of braces rather than parentheses.
 custom_error!{MyError{code:u8} = "error with code {code}."}
-```
-
-instead of
-
-```rust
-#[derive(Debug)]
-struct MyError {
-    code: u8,
-}
-
-impl std::error::Error for MyError {}
-
-impl std::fmt::Display for MyError {
-    fn fmt(&self, f: &mut std::fmt::Formatter)
-    -> std::fmt::Result {
-        write!(f, "error with code {}." , self.code)
-    }
-}
 ```
 
 ## Simple error

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ and a list of possible errors and generates a rust enumeration for all the cases
 together with the required `impl` blocks implementing `std::error::Error`
 and `std::fmt::Display`. 
 
+If you only have a single case for an error you can also generate a struct
+instead of an enum.
+
 You can now write:
 
 ```rust
@@ -39,6 +42,33 @@ impl std::fmt::Display for MyError {
             MyError::Unknown { code } => write!(f, "unknown error with code {}." , code),
             MyError::Err41 => write!(f, "Sit by a lake")
         }
+    }
+}
+```
+
+If you only have a single error case you can also generate a struct:
+```rust
+extern crate custom_error;
+use custom_error::custom_error;
+
+// Note the use of braces rather than parentheses.
+custom_error!{MyError{code:u8} = "error with code {code}."}
+```
+
+instead of
+
+```rust
+#[derive(Debug)]
+struct MyError {
+    code: u8,
+}
+
+impl std::error::Error for MyError {}
+
+impl std::fmt::Display for MyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter)
+    -> std::fmt::Result {
+        write!(f, "error with code {}." , self.code)
     }
 }
 ```
@@ -82,7 +112,7 @@ assert_eq!(
 ```
 
 The error messages can reference your parameters using braces (`{parameter_name}`).
-If you need some custom logic to display your parameters, you can use 
+If you need some custom logic to display your parameters, you can use
 [advanced custom error messages](#advanced-custom-error-messages).
 
 ## Wrapping other error types

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,9 +389,12 @@ mod tests {
     fn single_error_case() {
         custom_error!(MyError Bad="bad");
         assert_eq!("bad", MyError::Bad.to_string());
+    }
 
-        custom_error!(MyErrorStruct{} ="bad");
-        assert_eq!("bad", MyErrorStruct{}.to_string());
+    #[test]
+    fn single_error_struct_case() {
+        custom_error!(MyError{} ="bad");
+        assert_eq!("bad", MyError{}.to_string());
     }
 
     #[test]
@@ -412,9 +415,12 @@ mod tests {
             "9 things are broken",
             MyError::Catastrophic { broken_things: 9 }.to_string()
         );
+    }
 
-        custom_error!(MyErrorStruct{broken_things:u8} = "{broken_things} things are broken");
-        assert_eq!("9 things are broken", MyErrorStruct{ broken_things: 9 }.to_string());
+    #[test]
+    fn struct_with_error_data() {
+        custom_error!(MyError{broken_things:u8} = "{broken_things} things are broken");
+        assert_eq!("9 things are broken", MyError{ broken_things: 9 }.to_string());
     }
 
     #[test]
@@ -422,10 +428,13 @@ mod tests {
         custom_error!(E X{a:u8, b:u8, c:u8} = "{c} {b} {a}");
 
         assert_eq!("3 2 1", E::X { a: 1, b: 2, c: 3 }.to_string());
+    }
 
-        custom_error!(EStruct{a:u8, b:u8, c:u8} = "{c} {b} {a}");
+    #[test]
+    fn struct_with_multiple_error_data() {
+        custom_error!(E{a:u8, b:u8, c:u8} = "{c} {b} {a}");
 
-        assert_eq!("3 2 1", EStruct{ a: 1, b: 2, c: 3 }.to_string());
+        assert_eq!("3 2 1", E{ a: 1, b: 2, c: 3 }.to_string());
     }
 
     #[test]
@@ -462,10 +471,16 @@ mod tests {
     fn pub_error() {
         mod my_mod {
             custom_error! {pub MyError Case1="case1"}
-            custom_error! {pub MyErrorStruct{} = "case2"}
         }
         assert_eq!("case1", my_mod::MyError::Case1.to_string());
-        assert_eq!("case2", my_mod::MyErrorStruct{}.to_string());
+    }
+
+    #[test]
+    fn pub_error_struct() {
+        mod my_mod {
+            custom_error! {pub MyError{} = "case1"}
+        }
+        assert_eq!("case1", my_mod::MyError{}.to_string());
     }
 
     #[test]
@@ -473,18 +488,24 @@ mod tests {
         custom_error! {MyError<X,Y> E1{x:X,y:Y}="x={x} y={y}", E2="e2"}
         assert_eq!("x=42 y=42", MyError::E1 { x: 42u8, y: 42u8 }.to_string());
         assert_eq!("e2", MyError::E2::<u8, u8>.to_string());
+    }
 
-        custom_error! {MyErrorStruct<X,Y>{x:X,y:Y}="x={x} y={y}"}
-        assert_eq!("x=42 y=42", MyErrorStruct{ x: 42u8, y: 42u8 }.to_string());
+    #[test]
+    fn generic_error_struct() {
+        custom_error! {MyError<X,Y>{x:X,y:Y}="x={x} y={y}"}
+        assert_eq!("x=42 y=42", MyError{ x: 42u8, y: 42u8 }.to_string());
     }
 
     #[test]
     fn single_error_case_with_braces() {
         custom_error! {MyError Bad="bad"}
         assert_eq!("bad", MyError::Bad.to_string());
+    }
 
-        custom_error! {MyErrorStruct{} ="bad"}
-        assert_eq!("bad", MyErrorStruct{}.to_string())
+    #[test]
+    fn single_error_struct_case_with_braces() {
+        custom_error! {MyError{} ="bad"}
+        assert_eq!("bad", MyError{}.to_string())
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,18 +381,6 @@ macro_rules! add_type_bounds {
     }
 }
 
-#[doc(hidden)]
-#[macro_export]
-macro_rules! display_message_fun_for_struct {
-    ($self:ident, $formatter:expr, $($field_name:ident),* | $msg_fun:expr) => {
-        $(
-            let $field_name = $self.$field_name;
-        );*
-        write!($formatter, "{}", $msg_fun)?;
-    };
-    ($self:ident, $formatter:expr, $($field_name:ident),* | ) => {};
-}
-
 #[cfg(test)]
 mod tests {
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 ///
 /// ### Simple error
 ///
+/// For an error with multiple cases you can generate an enum:
 /// ```
 /// use custom_error::custom_error;
 ///
@@ -13,6 +14,14 @@
 /// }
 /// assert_eq!("Something bad happened",          MyError::Bad.to_string());
 /// assert_eq!("This is a very serious error!!!", MyError::Terrible.to_string());
+/// ```
+///
+/// For an error with a single case you can generate a struct:
+/// ```
+/// use custom_error::custom_error;
+///
+/// custom_error!{ pub MyError{} = "Something bad happened" }
+/// assert_eq!("Something bad happened", MyError{}.to_string());
 /// ```
 ///
 /// ### Custom error with parameters


### PR DESCRIPTION
Hi, 

Thanks for your package, saves lots of boilerplate!

I was looking at #16 and came up with the following idea:
```rust
custom_error!(MyErrorStruct{} ="bad");
assert_eq!("bad", MyErrorStruct{}.to_string());

custom_error!(MyErrorStruct{broken_things:u8} = "{broken_things} things are broken");
assert_eq!("9 things are broken", MyErrorStruct{ broken_things: 9 }.to_string());
```

I haven't done much with macros yet, so this is just an attempt of providing such functionality.
If you have any feedback or suggestions, I'd be happy to extend and adapt my pull request!

There is no handling for source attributes like you are doing for enum conversions yet.

All the best!
